### PR TITLE
Handle Zboss stack data initialization inside the context classes.

### DIFF
--- a/src/endpoints/dimmable_light/zigbee_dimmable_light.cpp
+++ b/src/endpoints/dimmable_light/zigbee_dimmable_light.cpp
@@ -1,5 +1,7 @@
 #include <mbed.h>
 #include "zigbee_dimmable_light.h"
+#include <vector>
+#include "../../Zigbee.h"
 
 DimmableLightCTX::DimmableLightCTX(float period_p, void (*aLightCB)(const uint8_t brightness_level)) : EndpointCTX(period_p)
 {
@@ -36,6 +38,87 @@ DimmableLightCTX::DimmableLightCTX(float period_p, void (*aLightCB)(const uint8_
     /* Level control cluster attributes data */
     level_control_attr.current_level = ZB_ZCL_LEVEL_CONTROL_LEVEL_MAX_VALUE; // Set current level value to maximum
     level_control_attr.remaining_time = ZB_ZCL_LEVEL_CONTROL_REMAINING_TIME_DEFAULT_VALUE;
+
+    m_zboss_specific_data.cluster_revision_scenes_attr_list = 1;
+    zb_zcl_attr_t scenes_attr_list[] = {
+        {0xfffdU, 0x21U, 0x01U, (void *)&(m_zboss_specific_data.cluster_revision_scenes_attr_list)},
+        {ZB_ZCL_ATTR_SCENES_SCENE_COUNT_ID, 0x20U, 0x01U, (void *)(&scenes_attr.scene_count)},
+        {ZB_ZCL_ATTR_SCENES_CURRENT_SCENE_ID, 0x20U, 0x01U, (void *)(&scenes_attr.current_scene)},
+        {ZB_ZCL_ATTR_SCENES_CURRENT_GROUP_ID, 0x21U, 0x01U, (void *)(&scenes_attr.current_group)},
+        {ZB_ZCL_ATTR_SCENES_SCENE_VALID_ID, 0x10U, 0x01U, (void *)(&scenes_attr.scene_valid)},
+        {ZB_ZCL_ATTR_SCENES_NAME_SUPPORT_ID, 0x18U, 0x01U, (void *)(&scenes_attr.name_support)},
+        {(zb_uint16_t)(-1), 0, 0, __null}};
+
+    static_assert(sizeof(m_zboss_specific_data.scenes_attr_list) == sizeof(scenes_attr_list), "Check vector size");
+    memcpy(m_zboss_specific_data.scenes_attr_list, scenes_attr_list, sizeof(scenes_attr_list));
+
+    m_zboss_specific_data.cluster_revision_groups_attr_list = 1;
+    zb_zcl_attr_t groups_attr_list[] = {
+        {0xfffdU, 0x21U, 0x01U, (void *)&(m_zboss_specific_data.cluster_revision_groups_attr_list)},
+        {ZB_ZCL_ATTR_GROUPS_NAME_SUPPORT_ID, 0x18U, 0x01U, (void *)(&groups_attr.name_support)},
+        {(zb_uint16_t)(-1), 0, 0, __null}};
+
+    static_assert(sizeof(m_zboss_specific_data.groups_attr_list) == sizeof(groups_attr_list), "Check vector size");
+    memcpy(m_zboss_specific_data.groups_attr_list, groups_attr_list, sizeof(groups_attr_list));
+
+    m_zboss_specific_data.cluster_revision_on_off_attr_list = 1;
+    zb_zcl_attr_t on_off_attr_list[] = {
+        {0xfffdU, 0x21U, 0x01U, (void *)&(m_zboss_specific_data.cluster_revision_on_off_attr_list)},
+        {ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID, 0x10U, 0x01U | 0x04U | 0x10U, (void *)(&on_off_attr.on_off)},
+        {ZB_ZCL_ATTR_ON_OFF_GLOBAL_SCENE_CONTROL, 0x10U, 0x01U, (void *)(&on_off_attr.global_scene_ctrl)},
+        {ZB_ZCL_ATTR_ON_OFF_ON_TIME, 0x21U, (0x01U | 0x02U), (void *)(&on_off_attr.on_time)},
+        {ZB_ZCL_ATTR_ON_OFF_OFF_WAIT_TIME, 0x21U, (0x01U | 0x02U), (void *)(&on_off_attr.off_wait_time)},
+        {(zb_uint16_t)(-1), 0, 0, __null}};
+    static_assert(sizeof(m_zboss_specific_data.on_off_attr_list) == sizeof(on_off_attr_list), "Check vector size");
+    memcpy(m_zboss_specific_data.on_off_attr_list, on_off_attr_list, sizeof(on_off_attr_list));
+
+    m_zboss_specific_data.cluster_revision_level_control_attr_list = 1;
+    zb_zcl_attr_t level_control_attr_list[] = {
+        {0xfffdU, 0x21U, 0x01U, (void *)&(m_zboss_specific_data.cluster_revision_level_control_attr_list)},
+        {ZB_ZCL_ATTR_LEVEL_CONTROL_CURRENT_LEVEL_ID, 0x20U, 0x01U | 0x04U | 0x10U, (void *)(&level_control_attr.current_level)},
+        {ZB_ZCL_ATTR_LEVEL_CONTROL_REMAINING_TIME_ID, 0x21U, 0x01U, (void *)(&level_control_attr.remaining_time)},
+        {ZB_ZCL_ATTR_LEVEL_CONTROL_MOVE_STATUS_ID, 0x00U, 0x40U, (void *)(&(m_zboss_specific_data.move_status_data_ctxdim_light))},
+        {(zb_uint16_t)(-1), 0, 0, __null}};
+    static_assert(sizeof(m_zboss_specific_data.level_control_attr_list) == sizeof(level_control_attr_list), "Check vector size");
+    memcpy(m_zboss_specific_data.level_control_attr_list, level_control_attr_list, sizeof(level_control_attr_list));
+
+    zb_zcl_cluster_desc_t dimmable_light_clusters[] = {
+        {(0x0003U), ((sizeof(m_zboss_data.identify_attr_list) / sizeof(zb_zcl_attr_t))), ((m_zboss_data.identify_attr_list)), (0x01U), (0x0000), (((0x01U) == 0x01U) ? zb_zcl_identify_init_server : (((0x01U) == 0x02U) ? zb_zcl_identify_init_client : __null))},
+        {(0x0000U), ((sizeof(m_zboss_data.basic_attr_list) / sizeof(zb_zcl_attr_t))), ((m_zboss_data.basic_attr_list)), (0x01U), (0x0000), (((0x01U) == 0x01U) ? zb_zcl_basic_init_server : (((0x01U) == 0x02U) ? zb_zcl_basic_init_client : __null))},
+        {(0x0005U), ((sizeof(m_zboss_specific_data.scenes_attr_list) / sizeof(zb_zcl_attr_t))), ((m_zboss_specific_data.scenes_attr_list)), (0x01U), (0x0000), (((0x01U) == 0x01U) ? zb_zcl_scenes_init_server : (((0x01U) == 0x02U) ? zb_zcl_scenes_init_client : __null))},
+        {(0x0004U), ((sizeof(m_zboss_specific_data.groups_attr_list) / sizeof(zb_zcl_attr_t))), ((m_zboss_specific_data.groups_attr_list)), (0x01U), (0x0000), (((0x01U) == 0x01U) ? zb_zcl_groups_init_server : (((0x01U) == 0x02U) ? zb_zcl_groups_init_client : __null))},
+        {(0x0006U), ((sizeof(m_zboss_specific_data.on_off_attr_list) / sizeof(zb_zcl_attr_t))), ((m_zboss_specific_data.on_off_attr_list)), (0x01U), (0x0000), (((0x01U) == 0x01U) ? zb_zcl_on_off_init_server : (((0x01U) == 0x02U) ? zb_zcl_on_off_init_client : __null))},
+        {(0x0008U), ((sizeof(m_zboss_specific_data.level_control_attr_list) / sizeof(zb_zcl_attr_t))), ((m_zboss_specific_data.level_control_attr_list)), (0x01U), (0x0000), (((0x01U) == 0x01U) ? zb_zcl_level_control_init_server : (((0x01U) == 0x02U) ? zb_zcl_level_control_init_client : __null))}};
+    static_assert(sizeof(m_zboss_specific_data.dimmable_light_clusters) == sizeof(dimmable_light_clusters), "Check vector size");
+    memcpy(m_zboss_specific_data.dimmable_light_clusters, dimmable_light_clusters, sizeof(dimmable_light_clusters));
+
+    m_zboss_specific_data.simple_desc = {
+        ep_id,
+        0x0104U,
+        ZB_HA_DIMMABLE_LIGHT_DEVICE_ID,
+        1,
+        0,
+        6,
+        0,
+        {0x0000U, 0x0003U, 0x0005U, 0x0004U, 0x0006U, 0x0008U}};
+
+    m_zboss_specific_data.dimmable_light_ep = {
+        ep_id,
+        0x0104U,
+        __null,
+        __null,
+        0,
+        (void *)__null,
+        (sizeof(m_zboss_specific_data.dimmable_light_clusters) / sizeof(zb_zcl_cluster_desc_t)),
+        m_zboss_specific_data.dimmable_light_clusters,
+        (zb_af_simple_desc_1_1_t *)&m_zboss_specific_data.simple_desc,
+        (1 + 1),
+        m_zboss_specific_data.reporting_infodimmable_light,
+        1,
+        m_zboss_specific_data.cvc_alarm_infodimmable_light};
+
+    set_desc(&m_zboss_specific_data.dimmable_light_ep);
+    Zigbee::getInstance().addEP(this);
 }
 
 zb_uint8_t DimmableLightCTX::endpoint_CB(zb_bufid_t bufid)
@@ -43,12 +126,12 @@ zb_uint8_t DimmableLightCTX::endpoint_CB(zb_bufid_t bufid)
     zb_bufid_t zcl_cmd_buf = bufid;
     zb_zcl_parsed_hdr_t *cmd_info = ZB_BUF_GET_PARAM(zcl_cmd_buf, zb_zcl_parsed_hdr_t);
 
-    if (    cmd_info->cmd_direction == ZB_ZCL_FRAME_DIRECTION_TO_SRV &&
-            !cmd_info->is_common_command &&
-            cmd_info->cluster_id == ZB_ZCL_CLUSTER_ID_ON_OFF &&
-            cmd_info->cmd_id == ZB_ZCL_CMD_ON_OFF_OFF_WITH_EFFECT_ID)
+    if (cmd_info->cmd_direction == ZB_ZCL_FRAME_DIRECTION_TO_SRV &&
+        !cmd_info->is_common_command &&
+        cmd_info->cluster_id == ZB_ZCL_CLUSTER_ID_ON_OFF &&
+        cmd_info->cmd_id == ZB_ZCL_CMD_ON_OFF_OFF_WITH_EFFECT_ID)
     {
-        setState((zb_bool_t)false);
+        setState((zb_bool_t) false);
 
         zb_buf_free(bufid);
 
@@ -92,7 +175,6 @@ void DimmableLightCTX::periodic_CB()
 
 //     return ZB_FALSE;
 // }
-
 
 void DimmableLightCTX::setAttribute(zb_zcl_set_attr_value_param_t *attr_p)
 {

--- a/src/endpoints/dimmable_light/zigbee_dimmable_light.h
+++ b/src/endpoints/dimmable_light/zigbee_dimmable_light.h
@@ -10,7 +10,6 @@ extern "C"
 }
 #include "../endpoint_ctx.h"
 
-
 class DimmableLightCTX : public EndpointCTX
 {
 public:
@@ -28,128 +27,43 @@ public:
     void setAttribute(zb_zcl_set_attr_value_param_t *attr_p);
     void setLevelControl(zb_zcl_level_control_set_value_param_t level_p);
 
-private:
     void setLevel(zb_uint8_t value);
     void setState(zb_bool_t value);
+
+    typedef struct zb_af_simple_desc_dimmable_light
+    {
+        zb_uint8_t endpoint;
+        zb_uint16_t app_profile_id;
+        zb_uint16_t app_device_id;
+        zb_bitfield_t app_device_version : 4;
+        zb_bitfield_t reserved : 4;
+        zb_uint8_t app_input_cluster_count;
+        zb_uint8_t app_output_cluster_count;
+        zb_uint16_t app_cluster_list[(6) + (0)];
+        zb_uint8_t cluster_encryption[((6) + (0) + 7) / 8];
+    } __attribute__((packed)) zb_af_simple_desc_dimmable_light;
+
+    typedef struct
+    {
+        zb_uint16_t cluster_revision_scenes_attr_list;
+        zb_zcl_attr_t scenes_attr_list[7];
+        zb_uint16_t cluster_revision_groups_attr_list;
+        zb_zcl_attr_t groups_attr_list[3];
+        zb_uint16_t cluster_revision_on_off_attr_list;
+        zb_zcl_attr_t on_off_attr_list[6];
+        zb_zcl_level_control_move_status_t move_status_data_ctxdim_light;
+        zb_uint16_t cluster_revision_level_control_attr_list;
+        zb_zcl_attr_t level_control_attr_list[5];
+        zb_zcl_cluster_desc_t dimmable_light_clusters[6];
+        zb_af_simple_desc_dimmable_light simple_desc;
+        zb_zcl_reporting_info_t reporting_infodimmable_light[2];
+        zb_zcl_cvc_alarm_variables_t cvc_alarm_infodimmable_light[1];
+        zb_af_endpoint_desc_t dimmable_light_ep;
+    } ZbossSpecificData;
+
+    ZbossSpecificData m_zboss_specific_data;
 };
-#define DimmableLight(CB)                                                                                      \                                                                                               
-    DimmableLightCTX dim_light_##CB(-1, CB);                                                                   \
-    ZB_ZCL_DECLARE_IDENTIFY_ATTRIB_LIST(identify_attr_list_##CB, &dim_light_##CB.identify_attr.identify_time); \
-    ZB_ZCL_DECLARE_GROUPS_ATTRIB_LIST(groups_attr_list_##CB, &dim_light_##CB.groups_attr.name_support);        \
-    ZB_ZCL_DECLARE_SCENES_ATTRIB_LIST(scenes_attr_list_##CB,                                                   \
-                                      &dim_light_##CB.scenes_attr.scene_count,                                 \
-                                      &dim_light_##CB.scenes_attr.current_scene,                               \
-                                      &dim_light_##CB.scenes_attr.current_group,                               \
-                                      &dim_light_##CB.scenes_attr.scene_valid,                                 \
-                                      &dim_light_##CB.scenes_attr.name_support);                               \
-    ZB_ZCL_DECLARE_BASIC_ATTRIB_LIST_EXT(basic_attr_list_##CB,                                                 \
-                                         &dim_light_##CB.basic_attr.zcl_version,                               \
-                                         &dim_light_##CB.basic_attr.app_version,                               \
-                                         &dim_light_##CB.basic_attr.stack_version,                             \
-                                         &dim_light_##CB.basic_attr.hw_version,                                \
-                                         dim_light_##CB.basic_attr.mf_name,                                    \
-                                         dim_light_##CB.basic_attr.model_id,                                   \
-                                         dim_light_##CB.basic_attr.date_code,                                  \
-                                         &dim_light_##CB.basic_attr.power_source,                              \
-                                         dim_light_##CB.basic_attr.location_id,                                \
-                                         &dim_light_##CB.basic_attr.ph_env,                                    \
-                                         dim_light_##CB.basic_attr.sw_ver);                                    \
-    ZB_ZCL_DECLARE_ON_OFF_ATTRIB_LIST_EXT(on_off_attr_list_##CB,                                               \
-                                          &dim_light_##CB.on_off_attr.on_off,                                  \
-                                          &dim_light_##CB.on_off_attr.global_scene_ctrl,                       \
-                                          &dim_light_##CB.on_off_attr.on_time,                                 \
-                                          &dim_light_##CB.on_off_attr.off_wait_time);                          \
-    ZB_ZCL_DECLARE_LEVEL_CONTROL_ATTRIB_LIST_VA(level_control_attr_list_##CB,                                  \
-                                                &dim_light_##CB.level_control_attr.current_level,              \
-                                                &dim_light_##CB.level_control_attr.remaining_time,             \
-                                                dim_light_##CB);                                               \
-    ZB_HA_DECLARE_DIMMABLE_LIGHT_CLUSTER_LIST(dimmable_light_clusters_##CB,                                    \
-                                              basic_attr_list_##CB,                                            \
-                                              identify_attr_list_##CB,                                         \
-                                              groups_attr_list_##CB,                                           \
-                                              scenes_attr_list_##CB,                                           \
-                                              on_off_attr_list_##CB,                                           \
-                                              level_control_attr_list_##CB);                                   \
-    ZB_HA_DECLARE_DIMMABLE_LIGHT_EP_VA(dimmable_light_ep_##CB,                                                 \
-                                       dim_light_##CB.ep_id,                                                   \
-                                       dimmable_light_clusters_##CB);                                          \
-    bool ep_desc##CB = dim_light_##CB.set_desc(&dimmable_light_ep_##CB);                                       \
-    int ep_add##CB = Zigbee::getInstance().addEP(&dim_light_##CB);
-
-/**@brief Declares attribute list for Level Control cluster, defined as variadic macro.
- *
- * @param[IN] attr_list          Attribure list name.
- * @param[IN] current_level      Pointer to variable to store the current_level attribute value.
- * @param[IN] remaining_time     Pointer to variable to store the remaining_time attribute value.
- * @param[IN] ...                Optional argument to concatenate to the variable name.
- */
-#define ZB_ZCL_DECLARE_LEVEL_CONTROL_ATTRIB_LIST_VA(attr_list, current_level, remaining_time, ...) \
-    zb_zcl_level_control_move_status_t move_status_data_ctx##__VA_ARGS__##_attr_list;              \
-    ZB_ZCL_START_DECLARE_ATTRIB_LIST(attr_list)                                                    \
-    ZB_ZCL_SET_ATTR_DESC(ZB_ZCL_ATTR_LEVEL_CONTROL_CURRENT_LEVEL_ID, (current_level))              \
-    ZB_ZCL_SET_ATTR_DESC(ZB_ZCL_ATTR_LEVEL_CONTROL_REMAINING_TIME_ID, (remaining_time))            \
-    ZB_ZCL_SET_ATTR_DESC(ZB_ZCL_ATTR_LEVEL_CONTROL_MOVE_STATUS_ID,                                 \
-                         (&(move_status_data_ctx##__VA_ARGS__##_attr_list)))                       \
-    ZB_ZCL_FINISH_DECLARE_ATTRIB_LIST
-
-/**@brief Declares endpoint, uses simple descriptor variadic macro to have multiple endpoints of the same type.
- *
- * @param[IN] ep_name            Endpoint name.
- * @param[IN] ep_id              Endpoint id.
- * @param[IN] cluster_list       List of cluster attribute lists
- */
-#define ZB_HA_DECLARE_DIMMABLE_LIGHT_EP_VA(ep_name, ep_id, cluster_list)          \
-    ZB_ZCL_DECLARE_DIMMABLE_LIGHT_SIMPLE_DESC_VA(                                 \
-        ep_name,                                                                  \
-        ep_id,                                                                    \
-        ZB_HA_DIMMABLE_LIGHT_IN_CLUSTER_NUM,                                      \
-        ZB_HA_DIMMABLE_LIGHT_OUT_CLUSTER_NUM);                                    \
-    ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info##ep_name,                   \
-                                       (ZB_HA_DIMMABLE_LIGHT_REPORT_ATTR_COUNT)); \
-    ZBOSS_DEVICE_DECLARE_LEVEL_CONTROL_CTX(cvc_alarm_info##ep_name,               \
-                                           ZB_HA_DIMMABLE_LIGHT_CVC_ATTR_COUNT);  \
-    ZB_AF_DECLARE_ENDPOINT_DESC(                                                  \
-        ep_name,                                                                  \
-        ep_id,                                                                    \
-        ZB_AF_HA_PROFILE_ID,                                                      \
-        0,                                                                        \
-        NULL,                                                                     \
-        ZB_ZCL_ARRAY_SIZE(                                                        \
-            cluster_list,                                                         \
-            zb_zcl_cluster_desc_t),                                               \
-        cluster_list,                                                             \
-        (zb_af_simple_desc_1_1_t *)&simple_desc_##ep_name,                        \
-        ZB_HA_DIMMABLE_LIGHT_REPORT_ATTR_COUNT,                                   \
-        reporting_info##ep_name,                                                  \
-        ZB_HA_DIMMABLE_LIGHT_CVC_ATTR_COUNT,                                      \
-        cvc_alarm_info##ep_name)
-
-/**@brief Declares endpoint, uses simple descriptor variadic macro to have multiple endpoints of the same type.
- *
- * @param[IN] ep_name            Endpoint name.
- * @param[IN] ep_id              Endpoint id.
- * @param[IN] in_clust_num       number of input clusters
- * @param[IN] out_clust_num      number of output clusters
- */
-#define ZB_ZCL_DECLARE_DIMMABLE_LIGHT_SIMPLE_DESC_VA(ep_name, ep_id, in_clust_num, out_clust_num) \
-    ZB_DECLARE_SIMPLE_DESC_VA(in_clust_num, out_clust_num, ep_name);                              \
-    ZB_AF_SIMPLE_DESC_TYPE_VA(in_clust_num, out_clust_num, ep_name)                               \
-    simple_desc_##ep_name =                                                                       \
-        {                                                                                         \
-            ep_id,                                                                                \
-            ZB_AF_HA_PROFILE_ID,                                                                  \
-            ZB_HA_DIMMABLE_LIGHT_DEVICE_ID,                                                       \
-            ZB_HA_DEVICE_VER_DIMMABLE_LIGHT,                                                      \
-            0,                                                                                    \
-            in_clust_num,                                                                         \
-            out_clust_num,                                                                        \
-            {                                                                                     \
-                ZB_ZCL_CLUSTER_ID_BASIC,                                                          \
-                ZB_ZCL_CLUSTER_ID_IDENTIFY,                                                       \
-                ZB_ZCL_CLUSTER_ID_SCENES,                                                         \
-                ZB_ZCL_CLUSTER_ID_GROUPS,                                                         \
-                ZB_ZCL_CLUSTER_ID_ON_OFF,                                                         \
-                ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL,                                                  \
-            }}
+#define DimmableLight(CB)                   \                                                                                               
+    DimmableLightCTX dim_light_##CB(-1, CB);
 
 #endif //ZIGBEE_DIM_LIGHT_H__

--- a/src/endpoints/endpoint_ctx.cpp
+++ b/src/endpoints/endpoint_ctx.cpp
@@ -9,9 +9,37 @@ EndpointCTX::EndpointCTX(float period_p) : period{period_p}
 
     /* Identify cluster attributes data */
     identify_attr.identify_time = ZB_ZCL_IDENTIFY_IDENTIFY_TIME_DEFAULT_VALUE;
+
+    m_zboss_data.cluster_revision_identify_attr_list = 1;
+    zb_zcl_attr_t identify_attr_list[] = {
+        {0xfffdU, 0x21U, 0x01U, (void *)&(m_zboss_data.cluster_revision_identify_attr_list)},
+        {ZB_ZCL_ATTR_IDENTIFY_IDENTIFY_TIME_ID, 0x21U, (0x01U | 0x02U), (void *)(&identify_attr.identify_time)},
+        {(zb_uint16_t)(-1), 0, 0, __null}};
+    static_assert(sizeof(m_zboss_data.identify_attr_list) == sizeof(identify_attr_list), "Check vector size");
+    memcpy(m_zboss_data.identify_attr_list, identify_attr_list, sizeof(identify_attr_list));
+
+    m_zboss_data.device_enable_basic_attr_list = 1U;
+    m_zboss_data.cluster_revision_basic_attr_list = 1;
+    zb_zcl_attr_t basic_attr_list[] = {
+        {0xfffdU, 0x21U, 0x01U, (void *)&(m_zboss_data.cluster_revision_basic_attr_list)},
+        {ZB_ZCL_ATTR_BASIC_ZCL_VERSION_ID, 0x20U, 0x01U, (void *)(&basic_attr.zcl_version)},
+        {ZB_ZCL_ATTR_BASIC_APPLICATION_VERSION_ID, 0x20U, 0x01U, (void *)(&basic_attr.app_version)},
+        {ZB_ZCL_ATTR_BASIC_STACK_VERSION_ID, 0x20U, 0x01U, (void *)(&basic_attr.stack_version)},
+        {ZB_ZCL_ATTR_BASIC_HW_VERSION_ID, 0x20U, 0x01U, (void *)(&basic_attr.hw_version)},
+        {ZB_ZCL_ATTR_BASIC_MANUFACTURER_NAME_ID, 0x42U, 0x01U, (void *)(basic_attr.mf_name)},
+        {ZB_ZCL_ATTR_BASIC_MODEL_IDENTIFIER_ID, 0x42U, 0x01U, (void *)(basic_attr.model_id)},
+        {ZB_ZCL_ATTR_BASIC_DATE_CODE_ID, 0x42U, 0x01U, (void *)(basic_attr.date_code)},
+        {ZB_ZCL_ATTR_BASIC_POWER_SOURCE_ID, 0x30U, 0x01U, (void *)(&basic_attr.power_source)},
+        {ZB_ZCL_ATTR_BASIC_SW_BUILD_ID, 0x42U, 0x01U, (void *)(basic_attr.sw_ver)},
+        {ZB_ZCL_ATTR_BASIC_DEVICE_ENABLED_ID, 0x10U, (0x01U | 0x02U), (void *)&(m_zboss_data.device_enable_basic_attr_list)},
+        {ZB_ZCL_ATTR_BASIC_LOCATION_DESCRIPTION_ID, 0x42U, (0x01U | 0x02U), (void *)(basic_attr.location_id)},
+        {ZB_ZCL_ATTR_BASIC_PHYSICAL_ENVIRONMENT_ID, 0x30U, (0x01U | 0x02U), (void *)(&basic_attr.ph_env)},
+        {(zb_uint16_t)(-1), 0, 0, __null}};
+    static_assert(sizeof(m_zboss_data.basic_attr_list) == sizeof(basic_attr_list), "Check vector size");
+    memcpy(m_zboss_data.basic_attr_list, basic_attr_list, sizeof(basic_attr_list));
 }
 
-bool EndpointCTX::set_desc(zb_af_endpoint_desc_t *ep_desc_p) // Setter function for ep_desc attribute
+bool EndpointCTX::set_desc(zb_af_endpoint_desc_t *ep_desc_p)
 {
     ep_desc = ep_desc_p;
     return 1;

--- a/src/endpoints/endpoint_ctx.h
+++ b/src/endpoints/endpoint_ctx.h
@@ -33,6 +33,17 @@ public:
     /* Virtual methods for cluster management */
     virtual void setAttribute(zb_zcl_set_attr_value_param_t *attr_p);
     virtual void setLevelControl(zb_zcl_level_control_set_value_param_t level_p);
+
+    typedef struct
+    {
+        zb_uint16_t cluster_revision_identify_attr_list;
+        zb_zcl_attr_t identify_attr_list[3];
+        zb_bool_t device_enable_basic_attr_list;
+        zb_uint16_t cluster_revision_basic_attr_list;
+        zb_zcl_attr_t basic_attr_list[14];
+    } ZbossData;
+
+    ZbossData m_zboss_data;
 };
 
 #endif

--- a/src/endpoints/temperature_sensor/zigbee_temperature_sensor.cpp
+++ b/src/endpoints/temperature_sensor/zigbee_temperature_sensor.cpp
@@ -1,6 +1,7 @@
 #include <mbed.h>
 #include "zigbee_temperature_sensor.h"
 #include <vector>
+#include "../../Zigbee.h"
 
 TemperatureSensorCTX::TemperatureSensorCTX(float period_p, float (*aTempCB)()) : EndpointCTX(period_p)
 {
@@ -32,12 +33,57 @@ TemperatureSensorCTX::TemperatureSensorCTX(float period_p, float (*aTempCB)()) :
 
     basic_attr.ph_env = ZB_ZCL_BASIC_ENV_UNSPECIFIED; /**< Description of the type of physical environment. For possible values, see section 3.2.2.2.10 of the ZCL specification. */
 
-
     /* Temperature measurement cluster attributes data */
     temp_attr.measure_value = ZB_ZCL_ATTR_TEMP_MEASUREMENT_VALUE_UNKNOWN;
     temp_attr.min_measure_value = ZB_ZCL_ATTR_TEMP_MEASUREMENT_MIN_VALUE_MIN_VALUE;
     temp_attr.max_measure_value = ZB_ZCL_ATTR_TEMP_MEASUREMENT_MAX_VALUE_MAX_VALUE;
     temp_attr.tolerance = ZB_ZCL_ATTR_TEMP_MEASUREMENT_TOLERANCE_MAX_VALUE;
+
+    m_zboss_specific_data.cluster_revision_temperature_attr_list = 1;
+    zb_zcl_attr_t temperature_attr_list[] = {
+        {0xfffdU, 0x21U, 0x01U, (void *)&(m_zboss_specific_data.cluster_revision_temperature_attr_list)},
+        {ZB_ZCL_ATTR_TEMP_MEASUREMENT_VALUE_ID, 0x29U, 0x01U | 0x04U, (void *)(&temp_attr.measure_value)},
+        {ZB_ZCL_ATTR_TEMP_MEASUREMENT_MIN_VALUE_ID, 0x29U, 0x01U, (void *)(&temp_attr.min_measure_value)},
+        {ZB_ZCL_ATTR_TEMP_MEASUREMENT_MAX_VALUE_ID, 0x29U, 0x01U, (void *)(&temp_attr.max_measure_value)},
+        {ZB_ZCL_ATTR_TEMP_MEASUREMENT_TOLERANCE_ID, 0x21U, 0x01U, (void *)(&temp_attr.tolerance)},
+        {(zb_uint16_t)(-1), 0, 0, __null}};
+    static_assert(sizeof(m_zboss_specific_data.temperature_attr_list) == sizeof(temperature_attr_list), "Check vector size");
+    memcpy(m_zboss_specific_data.temperature_attr_list, temperature_attr_list, sizeof(temperature_attr_list));
+
+    zb_zcl_cluster_desc_t temperature_sensor_clusters[] = {
+        {(0x0003U), ((sizeof(m_zboss_data.identify_attr_list) / sizeof(zb_zcl_attr_t))), ((m_zboss_data.identify_attr_list)), (0x01U), (0x0000), (((0x01U) == 0x01U) ? zb_zcl_identify_init_server : (((0x01U) == 0x02U) ? zb_zcl_identify_init_client : __null))},
+        {(0x0000U), ((sizeof(m_zboss_data.basic_attr_list) / sizeof(zb_zcl_attr_t))), ((m_zboss_data.basic_attr_list)), (0x01U), (0x0000), (((0x01U) == 0x01U) ? zb_zcl_basic_init_server : (((0x01U) == 0x02U) ? zb_zcl_basic_init_client : __null))},
+        {(0x0402U), ((sizeof(m_zboss_specific_data.temperature_attr_list) / sizeof(zb_zcl_attr_t))), ((m_zboss_specific_data.temperature_attr_list)), (0x01U), (0x0000), (((0x01U) == 0x01U) ? zb_zcl_temp_measurement_init_server : (((0x01U) == 0x02U) ? zb_zcl_temp_measurement_init_client : __null))},
+        {(0x0003U), (0), (__null), (0x02U), (0x0000), (((0x02U) == 0x01U) ? zb_zcl_identify_init_server : (((0x02U) == 0x02U) ? zb_zcl_identify_init_client : __null))}};
+    static_assert(sizeof(m_zboss_specific_data.temperature_sensor_clusters) == sizeof(temperature_sensor_clusters), "Check vector size");
+    memcpy(m_zboss_specific_data.temperature_sensor_clusters, temperature_sensor_clusters, sizeof(temperature_sensor_clusters));
+
+    m_zboss_specific_data.simple_desc_temperature_sensor = {
+        ep_id,
+        0x0104U,
+        ZB_HA_TEMPERATURE_SENSOR_DEVICE_ID,
+        0,
+        0,
+        3,
+        1,
+        {0x0000U, 0x0003U, 0x0402U, 0x0003U}};
+    m_zboss_specific_data.temperature_sensor = {
+        ep_id,
+        0x0104U,
+        __null,
+        __null,
+        0,
+        (void *)__null,
+        (sizeof(m_zboss_specific_data.temperature_sensor_clusters) / sizeof(zb_zcl_cluster_desc_t)),
+        m_zboss_specific_data.temperature_sensor_clusters,
+        (zb_af_simple_desc_1_1_t *)&m_zboss_specific_data.simple_desc_temperature_sensor,
+        (1),
+        m_zboss_specific_data.reporting_infotemperature_sensor,
+        0,
+        __null};
+
+    set_desc(&m_zboss_specific_data.temperature_sensor);
+    Zigbee::getInstance().addEP(this);
 };
 
 void TemperatureSensorCTX::periodic_CB()

--- a/src/endpoints/temperature_sensor/zigbee_temperature_sensor.h
+++ b/src/endpoints/temperature_sensor/zigbee_temperature_sensor.h
@@ -10,7 +10,6 @@ extern "C"
 }
 #include "../endpoint_ctx.h"
 
-
 class TemperatureSensorCTX : public EndpointCTX
 {
 public:
@@ -21,74 +20,34 @@ public:
     float (*tempCB)();                        // Callback defined in Arduino sketch
     void periodic_CB();                       // Periodic callback
     zb_uint8_t endpoint_CB(zb_bufid_t bufid); // Endpoint specific callback
+
+    typedef struct zb_af_simple_desc_temperature_sensor
+    {
+        zb_uint8_t endpoint;
+        zb_uint16_t app_profile_id;
+        zb_uint16_t app_device_id;
+        zb_bitfield_t app_device_version : 4;
+        zb_bitfield_t reserved : 4;
+        zb_uint8_t app_input_cluster_count;
+        zb_uint8_t app_output_cluster_count;
+        zb_uint16_t app_cluster_list[(3) + (1)];
+        zb_uint8_t cluster_encryption[((3) + (1) + 7) / 8];
+    } __attribute__((packed)) zb_af_simple_desc_temperature_sensor;
+
+    typedef struct
+    {
+        zb_uint16_t cluster_revision_temperature_attr_list;
+        zb_zcl_attr_t temperature_attr_list[6];
+        zb_zcl_cluster_desc_t temperature_sensor_clusters[4];
+        zb_af_simple_desc_temperature_sensor simple_desc_temperature_sensor;
+        zb_zcl_reporting_info_t reporting_infotemperature_sensor[1];
+        zb_af_endpoint_desc_t temperature_sensor;
+    } ZbossSpecificData;
+
+    ZbossSpecificData m_zboss_specific_data;
 };
 
-#define TemperatureSensor(CB)                                                                                  \
-    TemperatureSensorCTX temp_sens_##CB(30000, CB);                                                            \
-    ZB_ZCL_DECLARE_IDENTIFY_ATTRIB_LIST(identify_attr_list_##CB, &temp_sens_##CB.identify_attr.identify_time); \
-    ZB_ZCL_DECLARE_BASIC_ATTRIB_LIST_EXT(basic_attr_list_##CB,                                                 \
-                                         &temp_sens_##CB.basic_attr.zcl_version,                               \
-                                         &temp_sens_##CB.basic_attr.app_version,                               \
-                                         &temp_sens_##CB.basic_attr.stack_version,                             \
-                                         &temp_sens_##CB.basic_attr.hw_version,                                \
-                                         temp_sens_##CB.basic_attr.mf_name,                                    \
-                                         temp_sens_##CB.basic_attr.model_id,                                   \
-                                         temp_sens_##CB.basic_attr.date_code,                                  \
-                                         &temp_sens_##CB.basic_attr.power_source,                              \
-                                         temp_sens_##CB.basic_attr.location_id,                                \
-                                         &temp_sens_##CB.basic_attr.ph_env,                                    \
-                                         temp_sens_##CB.basic_attr.sw_ver);                                    \
-    ZB_ZCL_DECLARE_TEMP_MEASUREMENT_ATTRIB_LIST(temperature_attr_list_##CB,                                    \
-                                                &temp_sens_##CB.temp_attr.measure_value,                       \                      
-                                                &temp_sens_##CB.temp_attr.min_measure_value,                   \
-                                                &temp_sens_##CB.temp_attr.max_measure_value,                   \
-                                                &temp_sens_##CB.temp_attr.tolerance);                          \
-    ZB_HA_DECLARE_TEMPERATURE_SENSOR_CLUSTER_LIST(temperature_sensor_clusters_##CB,                            \
-                                                  basic_attr_list_##CB,                                        \
-                                                  identify_attr_list_##CB,                                     \
-                                                  temperature_attr_list_##CB);                                 \
-    ZB_HA_DECLARE_TEMPERATURE_SENSOR_EP_VA(temperature_sensor_ep_##CB,                                         \
-                                           temp_sens_##CB.ep_id,                                               \
-                                           temperature_sensor_clusters_##CB);                                  \
-    bool ep_desc##CB = temp_sens_##CB.set_desc(&temperature_sensor_ep_##CB);                                   \
-    int ep_add##CB = Zigbee::getInstance().addEP(&temp_sens_##CB);
-
-#define ZB_HA_DECLARE_TEMPERATURE_SENSOR_EP_VA(ep_name, ep_id, cluster_list)        \
-    ZB_ZCL_DECLARE_TEMPERATURE_SENSOR_SIMPLE_DESC_VA(                               \
-        ep_name,                                                                    \
-        ep_id,                                                                      \
-        ZB_HA_TEMPERATURE_SENSOR_IN_CLUSTER_NUM,                                    \
-        ZB_HA_TEMPERATURE_SENSOR_OUT_CLUSTER_NUM);                                  \
-    ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info##ep_name,                     \
-                                       ZB_HA_TEMPERATURE_SENSOR_REPORT_ATTR_COUNT); \
-    ZB_AF_DECLARE_ENDPOINT_DESC(                                                    \
-        ep_name,                                                                    \
-        ep_id,                                                                      \
-        ZB_AF_HA_PROFILE_ID,                                                        \
-        0,                                                                          \
-        NULL,                                                                       \
-        ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t),                     \
-        cluster_list,                                                               \
-        (zb_af_simple_desc_1_1_t *)&simple_desc_##ep_name,                          \
-        ZB_HA_TEMPERATURE_SENSOR_REPORT_ATTR_COUNT, reporting_info##ep_name, 0, NULL)
-
-#define ZB_ZCL_DECLARE_TEMPERATURE_SENSOR_SIMPLE_DESC_VA(ep_name, ep_id, in_clust_num, out_clust_num) \
-    ZB_DECLARE_SIMPLE_DESC_VA(in_clust_num, out_clust_num, ep_name);                                  \
-    ZB_AF_SIMPLE_DESC_TYPE_VA(in_clust_num, out_clust_num, ep_name)                                   \
-    simple_desc_##ep_name =                                                                           \
-        {                                                                                             \
-            ep_id,                                                                                    \
-            ZB_AF_HA_PROFILE_ID,                                                                      \
-            ZB_HA_TEMPERATURE_SENSOR_DEVICE_ID,                                                       \
-            ZB_HA_DEVICE_VER_TEMPERATURE_SENSOR,                                                      \
-            0,                                                                                        \
-            in_clust_num,                                                                             \
-            out_clust_num,                                                                            \
-            {                                                                                         \
-                ZB_ZCL_CLUSTER_ID_BASIC,                                                              \
-                ZB_ZCL_CLUSTER_ID_IDENTIFY,                                                           \
-                ZB_ZCL_CLUSTER_ID_TEMP_MEASUREMENT,                                                   \
-                ZB_ZCL_CLUSTER_ID_IDENTIFY,                                                           \
-            }}
+#define TemperatureSensor(CB) \
+    TemperatureSensorCTX temp_sens_##CB(30000, CB);
 
 #endif //ZIGBEE_TEMP_SENS_H__


### PR DESCRIPTION
With this improvement a Zigbee endpoint creation does not need to be wrapped using a macro.
The code has been written after expanding the content of Zboss initialization macros adding "-E -P" to the GCC call.